### PR TITLE
feat(cli): add argparse interface

### DIFF
--- a/src/krpsim/cli.py
+++ b/src/krpsim/cli.py
@@ -1,12 +1,38 @@
 """Command line interface for krpsim."""
 
-import sys
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Return the CLI argument parser."""
+
+    parser = argparse.ArgumentParser(prog="krpsim")
+    parser.add_argument("config", help="configuration file path")
+    parser.add_argument(
+        "delay",
+        type=int,
+        help="maximum delay allowed (positive integer)",
+    )
+    return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     """Entry point for the krpsim CLI."""
-    argv = argv or sys.argv[1:]
-    print("krpsim CLI placeholder", argv)
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    config_path = Path(args.config)
+    if not config_path.is_file():
+        parser.error(f"invalid config path: '{args.config}'")
+
+    if args.delay <= 0:
+        parser.error("delay must be a positive integer")
+
+    print("krpsim", args.config, args.delay)
     return 0
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,28 @@
+import pytest
+
 from krpsim import cli, verifier_cli
 
 
-def test_cli_main(capsys):
-    assert cli.main([]) == 0
+def test_cli_help(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["-h"])
+    assert exc.value.code == 0
     captured = capsys.readouterr()
-    assert "krpsim CLI placeholder" in captured.out
+    assert "usage:" in captured.out.lower()
+
+
+def test_cli_invalid_path():
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["/does/not/exist", "1"])
+    assert exc.value.code == 2
+
+
+def test_cli_invalid_delay(tmp_path):
+    config = tmp_path / "conf.txt"
+    config.write_text("dummy")
+    with pytest.raises(SystemExit) as exc:
+        cli.main([str(config), "0"])
+    assert exc.value.code == 2
 
 
 def test_verifier_cli_main(capsys):


### PR DESCRIPTION
## Summary
- implement CLI argument parser with validation
- test help message and argument validation

## Testing
- `ruff check .`
- `black --check src tests`
- `mypy src/krpsim tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687641b25ad08324941e2fe2ef5ffb14