### PR TITLE
feat: support optimize parsing

### DIFF
--- a/src/krpsim/parser.py
+++ b/src/krpsim/parser.py
@@ -23,6 +23,7 @@ class Config:
 
     stocks: dict[str, int]
     processes: dict[str, Process]
+    optimize: list[str] | None = None
 
 
 class ParseError(Exception):
@@ -52,7 +53,12 @@ def _parse_resources(block: str) -> dict[str, int]:
         name, qty = item.split(":", 1)
         if not qty.isdigit():
             raise ParseError(f"invalid quantity for resource '{item}'")
-        resources[name] = int(qty)
+        quantity = int(qty)
+        if quantity <= 0:
+            raise ParseError(f"invalid quantity for resource '{item}'")
+        if name in resources:
+            raise ParseError(f"duplicate resource '{name}' in '{block}'")
+        resources[name] = quantity
     return resources
 
 
@@ -66,18 +72,39 @@ def _parse_process(line: str) -> Process:
     return Process(name=name, needs=needs, results=results, delay=int(delay_str))
 
 
+def _parse_optimize(line: str) -> list[str]:
+    match = re.match(r"^optimize:\(([^)]*)\)$", line)
+    if not match:
+        raise ParseError(f"invalid optimize line: '{line}'")
+    block = match.group(1)
+    items = [item for item in block.split(";") if item]
+    if not items:
+        raise ParseError(f"invalid optimize line: '{line}'")
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in items:
+        if item in seen:
+            raise ParseError(f"duplicate optimize target '{item}'")
+        seen.add(item)
+        result.append(item)
+    return result
+
+
 def parse_file(path: Path) -> Config:
     """Parse a configuration file and return a :class:`Config`."""
 
     text = path.read_text().splitlines()
     stocks: dict[str, int] = {}
     processes: dict[str, Process] = {}
+    optimize: list[str] | None = None
     for line in text:
         line = line.strip()
         if not line or line.startswith("#"):
             continue
         if line.startswith("optimize:"):
-            # optimization settings are currently ignored
+            if optimize is not None:
+                raise ParseError("duplicate optimize line")
+            optimize = _parse_optimize(line)
             continue
         if ":(" in line:
             process = _parse_process(line)
@@ -93,4 +120,12 @@ def parse_file(path: Path) -> Config:
             raise ParseError(f"unrecognized line: '{line}'")
     if not stocks or not processes:
         raise ParseError("configuration must define at least one stock and process")
-    return Config(stocks=stocks, processes=processes)
+    if optimize:
+        known_resources: set[str] = set(stocks)
+        for proc in processes.values():
+            known_resources.update(proc.needs)
+            known_resources.update(proc.results)
+        for item in optimize:
+            if item != "time" and item not in known_resources:
+                raise ParseError(f"unknown stock '{item}' in optimize line")
+    return Config(stocks=stocks, processes=processes, optimize=optimize)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -45,3 +45,32 @@ def test_parse_resources_edge_cases():
     with pytest.raises(parser.ParseError):
         parser._parse_resources("a:bad")
 
+    with pytest.raises(parser.ParseError):
+        parser._parse_resources("a:-1")
+    with pytest.raises(parser.ParseError):
+        parser._parse_resources("a:1;a:2")
+
+
+def test_parse_optimize():
+    cfg = parser.parse_file(Path("resources/simple"))
+    assert cfg.optimize == ["time", "client_content"]
+
+
+def test_parse_optimize_errors(tmp_path):
+    config = tmp_path / "opt.txt"
+    config.write_text("a:1\nproc:(a:1):(b:1):1\noptimize:(c)\n")
+    with pytest.raises(parser.ParseError):
+        parser.parse_file(config)
+
+    config.write_text(
+        "a:1\nproc:(a:1):(b:1):1\noptimize:(time;time)\n"
+    )
+    with pytest.raises(parser.ParseError):
+        parser.parse_file(config)
+
+    config.write_text(
+        "a:1\nproc:(a:1):(b:1):1\noptimize:(time)\noptimize:(time)\n"
+    )
+    with pytest.raises(parser.ParseError):
+        parser.parse_file(config)
+


### PR DESCRIPTION
## Summary
- parse `optimize:` section in config files
- enforce positive quantities and check for duplicate resources
- validate optimize entries
- test optimize parsing and new validation errors

## Testing
- `poetry run ruff check src tests`
- `poetry run mypy src tests`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68766dc5ee988324a8b2ae754eb2d061