### PR TITLE
feat: basic simulator implementation

### DIFF
--- a/src/krpsim/simulator.py
+++ b/src/krpsim/simulator.py
@@ -1,0 +1,59 @@
+"""Simple simulator running processes cycle by cycle."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .parser import Config, Process
+
+
+@dataclass
+class _RunningProcess:
+    process: Process
+    remaining: int
+
+
+class Simulator:
+    """Run processes from a :class:`Config` over discrete cycles."""
+
+    def __init__(self, config: Config):
+        self.config = config
+        self.stocks: dict[str, int] = config.stocks.copy()
+        self.time = 0
+        self._running: list[_RunningProcess] = []
+        self.trace: list[tuple[int, str]] = []
+
+    def _complete_running(self) -> None:
+        completed: list[_RunningProcess] = []
+        for rp in self._running:
+            rp.remaining -= 1
+            if rp.remaining == 0:
+                for name, qty in rp.process.results.items():
+                    self.stocks[name] = self.stocks.get(name, 0) + qty
+                completed.append(rp)
+        for rp in completed:
+            self._running.remove(rp)
+
+    def _start_processes(self) -> bool:
+        started = False
+        for process in sorted(self.config.processes.values(), key=lambda p: p.name):
+            if all(
+                self.stocks.get(name, 0) >= qty for name, qty in process.needs.items()
+            ):
+                for name, qty in process.needs.items():
+                    self.stocks[name] -= qty
+                self._running.append(_RunningProcess(process, process.delay))
+                self.trace.append((self.time, process.name))
+                started = True
+        return started
+
+    def step(self) -> bool:
+        self._complete_running()
+        started = self._start_processes()
+        self.time += 1
+        return started or bool(self._running)
+
+    def run(self, max_time: int) -> list[tuple[int, str]]:
+        while self.time < max_time and self.step():
+            pass
+        return self.trace

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,3 +29,11 @@ def test_verifier_cli_main(capsys):
     assert verifier_cli.main([]) == 0
     captured = capsys.readouterr()
     assert "krpsim verifier placeholder" in captured.out
+
+
+def test_cli_valid(tmp_path, capsys):
+    config = tmp_path / "conf.txt"
+    config.write_text("a:1\nproc:(a:1):(b:1):1\n")
+    assert cli.main([str(config), "5"]) == 0
+    captured = capsys.readouterr()
+    assert "krpsim" in captured.out

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -67,3 +67,28 @@ def test_parse_optimize_errors(tmp_path):
     config.write_text("a:1\nproc:(a:1):(b:1):1\noptimize:(time)\noptimize:(time)\n")
     with pytest.raises(parser.ParseError):
         parser.parse_file(config)
+
+
+def test_internal_parser_functions(tmp_path):
+    with pytest.raises(parser.ParseError):
+        parser._parse_stock("bad")
+    with pytest.raises(parser.ParseError):
+        parser._parse_stock("a:-1")
+    with pytest.raises(parser.ParseError):
+        parser._parse_process("bad")
+    with pytest.raises(parser.ParseError):
+        parser._parse_optimize("bad")
+
+    empty = tmp_path / "empty.txt"
+    empty.write_text("")
+    with pytest.raises(parser.ParseError):
+        parser.parse_file(empty)
+
+    config = tmp_path / "tmp.txt"
+    config.write_text("a:1\nproc:(a:1):(b:1):1\noptimize:(time;time)\n")
+    with pytest.raises(parser.ParseError):
+        parser.parse_file(config)
+
+    config.write_text("a:1\nproc:(a:1):(b:1):1\noptimize:(time)\noptimize:(time)\n")
+    with pytest.raises(parser.ParseError):
+        parser.parse_file(config)

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from krpsim import parser
+from krpsim.simulator import Simulator
+
+
+def test_run_simple(tmp_path):
+    cfg = parser.parse_file(Path("resources/simple"))
+    sim = Simulator(cfg)
+    trace = sim.run(100)
+    assert trace == [
+        (0, "achat_materiel"),
+        (10, "realisation_produit"),
+        (40, "livraison"),
+    ]
+    assert sim.stocks["euro"] == 2
+    assert sim.stocks["client_content"] == 1
+
+
+def test_parallel_processes():
+    cfg = parser.Config(
+        stocks={"a": 2},
+        processes={
+            "p1": parser.Process("p1", {"a": 1}, {"b": 1}, 2),
+            "p2": parser.Process("p2", {"a": 1}, {"c": 1}, 2),
+        },
+    )
+    sim = Simulator(cfg)
+    trace = sim.run(5)
+    assert trace == [(0, "p1"), (0, "p2")]
+    assert sim.stocks["b"] == 1
+    assert sim.stocks["c"] == 1
+    assert sim.stocks["a"] == 0
+
+
+def test_no_process_possible():
+    cfg = parser.Config(stocks={"a": 1}, processes={})
+    sim = Simulator(cfg)
+    trace = sim.run(3)
+    assert trace == []
+    assert sim.stocks["a"] == 1


### PR DESCRIPTION
## Summary
- add simulation engine with cycle execution
- support concurrent process start and stock updates
- cover simulator logic with new unit tests
- expand CLI and parser tests for better coverage

## Testing
- `poetry run ruff check src tests`
- `poetry run mypy src tests`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68778ed954508324ba9c07ce10182f95