### PR TITLE
feat: add optimizer for process selection

### DIFF
--- a/src/krpsim/optimizer.py
+++ b/src/krpsim/optimizer.py
@@ -1,0 +1,22 @@
+"""Process ordering logic for the simulator (Agent 3)."""
+
+from __future__ import annotations
+
+from .parser import Config, Process
+
+
+def order_processes(config: Config) -> list[Process]:
+    """Return processes sorted according to ``config.optimize``."""
+
+    def sort_key(proc: Process) -> tuple[int | str, ...]:
+        key: list[int | str] = []
+        if config.optimize:
+            for target in config.optimize:
+                if target == "time":
+                    key.append(proc.delay)
+                else:
+                    key.append(-proc.results.get(target, 0))
+        key.append(proc.name)
+        return tuple(key)
+
+    return sorted(config.processes.values(), key=sort_key)

--- a/src/krpsim/simulator.py
+++ b/src/krpsim/simulator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from .parser import Config, Process
+from .optimizer import order_processes
 
 
 @dataclass
@@ -36,7 +37,7 @@ class Simulator:
 
     def _start_processes(self) -> bool:
         started = False
-        for process in sorted(self.config.processes.values(), key=lambda p: p.name):
+        for process in order_processes(self.config):
             if all(
                 self.stocks.get(name, 0) >= qty for name, qty in process.needs.items()
             ):

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -39,3 +39,31 @@ def test_no_process_possible():
     trace = sim.run(3)
     assert trace == []
     assert sim.stocks["a"] == 1
+
+
+def test_optimize_time_priority():
+    cfg = parser.Config(
+        stocks={"a": 1},
+        processes={
+            "p1": parser.Process("p1", {"a": 1}, {"b": 1}, 5),
+            "p2": parser.Process("p2", {"a": 1}, {"c": 1}, 3),
+        },
+        optimize=["time"],
+    )
+    sim = Simulator(cfg)
+    trace = sim.run(10)
+    assert trace[0] == (0, "p2")
+
+
+def test_optimize_stock_priority():
+    cfg = parser.Config(
+        stocks={"a": 1},
+        processes={
+            "p1": parser.Process("p1", {"a": 1}, {"b": 1}, 5),
+            "p2": parser.Process("p2", {"a": 1}, {"c": 1}, 3),
+        },
+        optimize=["b"],
+    )
+    sim = Simulator(cfg)
+    trace = sim.run(10)
+    assert trace[0] == (0, "p1")


### PR DESCRIPTION
## Summary
- implement `order_processes` to sort processes according to the `optimize` list
- integrate optimizer with the simulator
- test prioritization by `time` or stock name

## Testing
- `ruff check src tests`
- `mypy src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68779c6ebaf08324a22d13ef3e8e91c9