### PR TITLE
feat: output machine trace

### DIFF
--- a/src/krpsim/cli.py
+++ b/src/krpsim/cli.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+from . import parser as parser_mod
+from .display import print_header, save_trace, format_trace
+from .simulator import Simulator
 
 def build_parser() -> argparse.ArgumentParser:
     """Return the CLI argument parser."""
@@ -15,6 +18,11 @@ def build_parser() -> argparse.ArgumentParser:
         "delay",
         type=int,
         help="maximum delay allowed (positive integer)",
+    )
+    parser.add_argument(
+        "--trace",
+        default="trace.txt",
+        help="path of the file to write machine trace to",
     )
     return parser
 
@@ -32,7 +40,23 @@ def main(argv: list[str] | None = None) -> int:
     if args.delay <= 0:
         parser.error("delay must be a positive integer")
 
-    print("krpsim", args.config, args.delay)
+    config = parser_mod.parse_file(config_path)
+    sim = Simulator(config)
+
+    print_header(config)
+    trace = sim.run(args.delay)
+    for line in format_trace(trace):
+        print(line)
+
+    if sim.time >= args.delay:
+        print(f"max time reached at time {sim.time}")
+    else:
+        print(f"no more process doable at time {sim.time}")
+    print("Stock:")
+    for name, qty in sim.stocks.items():
+        print(f"{name} => {qty}")
+
+    save_trace(trace, Path(args.trace))
     return 0
 
 

--- a/src/krpsim/display.py
+++ b/src/krpsim/display.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""Display utilities producing human messages and machine trace."""
+
+import os
+from pathlib import Path
+from typing import Iterable
+
+from .parser import Config
+
+
+def print_header(config: Config) -> None:
+    """Print introduction lines about the config."""
+    optimize_count = len(config.optimize or [])
+    print(
+        f"Nice file! {len(config.processes)} processes, {len(config.stocks)} stocks, {optimize_count} to optimize"
+    )
+    print("Evaluating ... done.")
+    print("Main walk")
+
+
+def format_trace(trace: Iterable[tuple[int, str]]) -> list[str]:
+    """Return a list of ``cycle:process`` lines."""
+    return [f"{cycle}:{name}" for cycle, name in trace]
+
+
+def save_trace(trace: Iterable[tuple[int, str]], path: Path) -> None:
+    """Save ``trace`` to ``path`` and flush to disk."""
+    lines = format_trace(trace)
+    with path.open("w", encoding="utf-8") as fh:
+        for line in lines:
+            fh.write(line + "\n")
+        fh.flush()
+        os.fsync(fh.fileno())
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,6 +34,9 @@ def test_verifier_cli_main(capsys):
 def test_cli_valid(tmp_path, capsys):
     config = tmp_path / "conf.txt"
     config.write_text("a:1\nproc:(a:1):(b:1):1\n")
-    assert cli.main([str(config), "5"]) == 0
+    trace_path = tmp_path / "trace.txt"
+    assert cli.main([str(config), "5", "--trace", str(trace_path)]) == 0
     captured = capsys.readouterr()
-    assert "krpsim" in captured.out
+    assert "Main walk" in captured.out
+    assert "0:proc" in captured.out
+    assert trace_path.read_text().splitlines() == ["0:proc"]

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from krpsim.display import format_trace, save_trace
+
+
+def test_format_trace():
+    trace = [(0, "p1"), (10, "p2")]
+    assert format_trace(trace) == ["0:p1", "10:p2"]
+
+
+def test_save_trace(tmp_path: Path):
+    trace = [(0, "p1"), (5, "p2")]
+    target = tmp_path / "trace.txt"
+    save_trace(trace, target)
+    assert target.read_text().splitlines() == ["0:p1", "5:p2"]
+
+


### PR DESCRIPTION
## Summary
- write a small display helper to save traces to disk
- add human-readable output and trace writing in CLI
- test the CLI trace output and display helpers

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877a372b8a883248212f95ba1180380