### PR TITLE
feat: verifier implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,6 @@ test:
 
 ARGS ?=
 
-
 run:
 	poetry run krpsim $(ARGS)
+

--- a/src/krpsim/cli.py
+++ b/src/krpsim/cli.py
@@ -6,8 +6,9 @@ import argparse
 from pathlib import Path
 
 from . import parser as parser_mod
-from .display import print_header, save_trace, format_trace
+from .display import format_trace, print_header, save_trace
 from .simulator import Simulator
+
 
 def build_parser() -> argparse.ArgumentParser:
     """Return the CLI argument parser."""

--- a/src/krpsim/display.py
+++ b/src/krpsim/display.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Display utilities producing human messages and machine trace."""
+
+from __future__ import annotations
 
 import os
 from pathlib import Path
@@ -13,7 +13,9 @@ def print_header(config: Config) -> None:
     """Print introduction lines about the config."""
     optimize_count = len(config.optimize or [])
     print(
-        f"Nice file! {len(config.processes)} processes, {len(config.stocks)} stocks, {optimize_count} to optimize"
+        "Nice file! "
+        f"{len(config.processes)} processes, {len(config.stocks)} stocks, "
+        f"{optimize_count} to optimize"
     )
     print("Evaluating ... done.")
     print("Main walk")

--- a/src/krpsim/simulator.py
+++ b/src/krpsim/simulator.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .parser import Config, Process
 from .optimizer import order_processes
+from .parser import Config, Process
 
 
 @dataclass

--- a/src/krpsim/verifier.py
+++ b/src/krpsim/verifier.py
@@ -1,0 +1,77 @@
+"""Trace verification utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .parser import Config, parse_file
+from .simulator import Simulator
+
+
+class TraceError(Exception):
+    """Raised when a trace is invalid."""
+
+
+@dataclass
+class TraceEntry:
+    cycle: int
+    process: str
+
+
+def parse_trace(path: Path) -> list[TraceEntry]:
+    """Return trace entries parsed from ``path``."""
+
+    lines = path.read_text().splitlines()
+    entries: list[TraceEntry] = []
+    for idx, line in enumerate(lines, start=1):
+        if not line:
+            raise TraceError(f"empty trace line {idx}")
+        if ":" not in line:
+            raise TraceError(f"invalid trace line {idx}: '{line}'")
+        cycle_str, name = line.split(":", 1)
+        if not cycle_str.isdigit():
+            raise TraceError(f"invalid trace line {idx}: '{line}'")
+        entries.append(TraceEntry(int(cycle_str), name))
+    return entries
+
+
+def _expected_trace(config: Config) -> list[TraceEntry]:
+    sim = Simulator(config)
+    raw = sim.run(10_000)
+    return [TraceEntry(cycle, name) for cycle, name in raw]
+
+
+def verify_trace(config: Config, trace: list[TraceEntry]) -> None:
+    """Validate ``trace`` against ``config``.
+
+    Raises :class:`TraceError` at the first mismatch.
+    """
+
+    expected = _expected_trace(config)
+    for idx, (got, exp) in enumerate(zip(trace, expected), start=1):
+        if got != exp:
+            raise TraceError(
+                f"line {idx}: expected {exp.cycle}:{exp.process} "
+                f"but got {got.cycle}:{got.process}"
+            )
+
+    if len(trace) < len(expected):
+        missing = expected[len(trace)]
+        raise TraceError(
+            f"trace ended early at line {len(trace)+1}, "
+            f"expected {missing.cycle}:{missing.process}"
+        )
+
+    if len(trace) > len(expected):
+        raise TraceError(
+            f"trace has extra events starting at line {len(expected)+1}"
+        )
+
+
+def verify_files(config_path: Path, trace_path: Path) -> None:
+    """Convenience wrapper verifying files."""
+
+    config = parse_file(config_path)
+    trace = parse_trace(trace_path)
+    verify_trace(config, trace)

--- a/src/krpsim/verifier_cli.py
+++ b/src/krpsim/verifier_cli.py
@@ -1,12 +1,34 @@
 """Verifier command line interface."""
 
-import sys
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .parser import ParseError
+from .verifier import TraceError, verify_files
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Return the CLI argument parser."""
+
+    parser = argparse.ArgumentParser(prog="krpsim-verif")
+    parser.add_argument("config", help="configuration file path")
+    parser.add_argument("trace", help="execution trace file path")
+    return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     """Entry point for the krpsim verifier."""
-    argv = argv or sys.argv[1:]
-    print("krpsim verifier placeholder", argv)
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        verify_files(Path(args.config), Path(args.trace))
+    except (OSError, ParseError, TraceError) as exc:
+        print(f"invalid trace: {exc}")
+        return 1
+    print("trace is valid")
     return 0
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,10 +25,32 @@ def test_cli_invalid_delay(tmp_path):
     assert exc.value.code == 2
 
 
-def test_verifier_cli_main(capsys):
-    assert verifier_cli.main([]) == 0
+def test_verifier_cli_help(capsys):
+    with pytest.raises(SystemExit) as exc:
+        verifier_cli.main(["-h"])
+    assert exc.value.code == 0
     captured = capsys.readouterr()
-    assert "krpsim verifier placeholder" in captured.out
+    assert "usage" in captured.out.lower()
+
+
+def test_verifier_cli_valid(tmp_path, capsys):
+    cfg = tmp_path / "conf.txt"
+    cfg.write_text("a:1\nproc:(a:1):(b:1):1\n")
+    trace = tmp_path / "trace.txt"
+    trace.write_text("0:proc\n")
+    assert verifier_cli.main([str(cfg), str(trace)]) == 0
+    captured = capsys.readouterr()
+    assert "trace is valid" in captured.out
+
+
+def test_verifier_cli_error(tmp_path, capsys):
+    cfg = tmp_path / "conf.txt"
+    cfg.write_text("a:1\nproc:(a:1):(b:1):1\n")
+    trace = tmp_path / "trace.txt"
+    trace.write_text("0:oops\n")
+    assert verifier_cli.main([str(cfg), str(trace)]) == 1
+    captured = capsys.readouterr()
+    assert "invalid trace" in captured.out
 
 
 def test_cli_valid(tmp_path, capsys):

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -3,12 +3,12 @@ from pathlib import Path
 from krpsim.display import format_trace, save_trace
 
 
-def test_format_trace():
+def test_format_trace() -> None:
     trace = [(0, "p1"), (10, "p2")]
     assert format_trace(trace) == ["0:p1", "10:p2"]
 
 
-def test_save_trace(tmp_path: Path):
+def test_save_trace(tmp_path: Path) -> None:
     trace = [(0, "p1"), (5, "p2")]
     target = tmp_path / "trace.txt"
     save_trace(trace, target)

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import pytest
+
+from krpsim import parser
+from krpsim.simulator import Simulator
+from krpsim.verifier import TraceError, parse_trace, verify_trace
+
+
+def test_verify_trace_valid(tmp_path: Path) -> None:
+    cfg = parser.parse_file(Path("resources/simple"))
+    sim = Simulator(cfg)
+    events = sim.run(100)
+    trace_file = tmp_path / "trace.txt"
+    trace_file.write_text("\n".join(f"{c}:{n}" for c, n in events))
+    trace = parse_trace(trace_file)
+    verify_trace(cfg, trace)
+
+
+def test_verify_trace_error(tmp_path: Path) -> None:
+    cfg = parser.parse_file(Path("resources/simple"))
+    bad_trace = tmp_path / "bad.txt"
+    bad_trace.write_text("0:oops\n")
+    trace = parse_trace(bad_trace)
+    with pytest.raises(TraceError):
+        verify_trace(cfg, trace)


### PR DESCRIPTION
## Summary
- implement trace verification module
- flesh out verifier CLI using new module
- adjust display output formatting
- add tests for trace verification and CLI

## Testing
- `make format`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6877a62e5d388324a664f0fd8008c82e