### PR TITLE
test: enforce 100% coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ addopts    = [
   "--cov-report=term-missing",
   "--cov-report=html",
   "--cov-report=xml",
-  "--cov-fail-under=90"
+  "--cov-fail-under=100"
 ]
 testpaths        = ["tests"]
 python_files     = ["test_*.py"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,3 +62,12 @@ def test_cli_valid(tmp_path, capsys):
     assert "Main walk" in captured.out
     assert "0:proc" in captured.out
     assert trace_path.read_text().splitlines() == ["0:proc"]
+
+
+def test_cli_max_time(tmp_path, capsys):
+    config = tmp_path / "conf.txt"
+    config.write_text("a:1\nproc:(a:1):(b:1):1\n")
+    trace_path = tmp_path / "trace.txt"
+    assert cli.main([str(config), "1", "--trace", str(trace_path)]) == 0
+    captured = capsys.readouterr()
+    assert "max time reached" in captured.out

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -122,3 +122,29 @@ def test_parse_long_line_rejected(tmp_path):
     cfg.write_bytes(long_line)
     with pytest.raises(parser.ParseError):
         parser.parse_file(cfg)
+
+
+class _FakeQty(str):
+    def isdigit(self) -> bool:  # type: ignore[override]
+        return True
+
+
+class _FakeLine:
+    def split(self, sep: str, maxsplit: int = 1):  # type: ignore[override]
+        return ["a", _FakeQty("-1")]
+
+
+def test_parse_stock_negative() -> None:
+    with pytest.raises(parser.ParseError):
+        parser._parse_stock(_FakeLine())
+
+
+def test_parse_resources_edge_cases_continued():
+    assert parser._parse_resources("a:1;;b:1") == {"a": 1, "b": 1}
+    with pytest.raises(parser.ParseError):
+        parser._parse_resources("a:0")
+
+
+def test_parse_optimize_empty():
+    with pytest.raises(parser.ParseError):
+        parser._parse_optimize("optimize:()")

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -24,3 +24,31 @@ def test_verify_trace_error(tmp_path: Path) -> None:
     trace = parse_trace(bad_trace)
     with pytest.raises(TraceError):
         verify_trace(cfg, trace)
+
+
+@pytest.mark.parametrize(
+    "content",
+    ["", "0proc", "x:proc"],
+)
+def test_parse_trace_errors(tmp_path: Path, content: str) -> None:
+    file = tmp_path / "trace.txt"
+    file.write_text(content + "\n")
+    with pytest.raises(TraceError):
+        parse_trace(file)
+
+
+def test_verify_trace_short_and_extra(tmp_path: Path) -> None:
+    cfg = parser.parse_file(Path("resources/simple"))
+    sim = Simulator(cfg)
+    events = sim.run(100)
+
+    short_file = tmp_path / "short.txt"
+    short_file.write_text("\n".join(f"{c}:{n}" for c, n in events[:-1]))
+    with pytest.raises(TraceError):
+        verify_trace(cfg, parse_trace(short_file))
+
+    extra_file = tmp_path / "extra.txt"
+    extra_events = events + [(999, "extra")]
+    extra_file.write_text("\n".join(f"{c}:{n}" for c, n in extra_events))
+    with pytest.raises(TraceError):
+        verify_trace(cfg, parse_trace(extra_file))


### PR DESCRIPTION
## Summary
- require 100% coverage in `pyproject.toml`
- add tests for CLI max-time branch
- add parser edge case tests
- exercise error paths in trace verification

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6877b8de16448324ab71c43e25a69af4