### PR TITLE
feat: verbose mode and logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ install:
 	poetry install
 
 lint:
-	poetry run ruff src tests
+	poetry run ruff check src tests
 	poetry run mypy src tests
 
 format:

--- a/src/krpsim/cli.py
+++ b/src/krpsim/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 from pathlib import Path
 
 from . import parser as parser_mod
@@ -25,6 +26,16 @@ def build_parser() -> argparse.ArgumentParser:
         default="trace.txt",
         help="path of the file to write machine trace to",
     )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="enable verbose logging",
+    )
+    parser.add_argument(
+        "--log",
+        help="path to write logs to",
+    )
     return parser
 
 
@@ -33,6 +44,16 @@ def main(argv: list[str] | None = None) -> int:
 
     parser = build_parser()
     args = parser.parse_args(argv)
+
+    handlers: list[logging.Handler] = [logging.StreamHandler()]
+    if args.log:
+        handlers.append(logging.FileHandler(args.log))
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(message)s",
+        handlers=handlers,
+        force=True,
+    )
 
     config_path = Path(args.config)
     if not config_path.is_file():

--- a/src/krpsim/display.py
+++ b/src/krpsim/display.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from typing import Iterable
@@ -34,4 +35,5 @@ def save_trace(trace: Iterable[tuple[int, str]], path: Path) -> None:
             fh.write(line + "\n")
         fh.flush()
         os.fsync(fh.fileno())
+    logging.getLogger(__name__).info("trace saved to %s", path)
 

--- a/src/krpsim/simulator.py
+++ b/src/krpsim/simulator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 from .optimizer import order_processes
@@ -37,6 +38,7 @@ class Simulator:
 
     def _start_processes(self) -> bool:
         started = False
+        logger = logging.getLogger(__name__)
         for process in order_processes(self.config):
             if all(
                 self.stocks.get(name, 0) >= qty for name, qty in process.needs.items()
@@ -45,6 +47,7 @@ class Simulator:
                     self.stocks[name] -= qty
                 self._running.append(_RunningProcess(process, process.delay))
                 self.trace.append((self.time, process.name))
+                logger.info("%d:%s", self.time, process.name)
                 started = True
         return started
 

--- a/src/krpsim/verifier_cli.py
+++ b/src/krpsim/verifier_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 from pathlib import Path
 
 from .parser import ParseError
@@ -15,6 +16,13 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="krpsim-verif")
     parser.add_argument("config", help="configuration file path")
     parser.add_argument("trace", help="execution trace file path")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="enable verbose logging",
+    )
+    parser.add_argument("--log", help="file to write logs to")
     return parser
 
 
@@ -23,11 +31,24 @@ def main(argv: list[str] | None = None) -> int:
 
     parser = build_parser()
     args = parser.parse_args(argv)
+
+    handlers: list[logging.Handler] = [logging.StreamHandler()]
+    if args.log:
+        handlers.append(logging.FileHandler(args.log))
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(message)s",
+        handlers=handlers,
+        force=True,
+    )
+
     try:
         verify_files(Path(args.config), Path(args.trace))
     except (OSError, ParseError, TraceError) as exc:
+        logging.error("invalid trace: %s", exc)
         print(f"invalid trace: {exc}")
         return 1
+    logging.info("trace is valid")
     print("trace is valid")
     return 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,3 +71,40 @@ def test_cli_max_time(tmp_path, capsys):
     assert cli.main([str(config), "1", "--trace", str(trace_path)]) == 0
     captured = capsys.readouterr()
     assert "max time reached" in captured.out
+
+
+def test_cli_verbose_and_log(tmp_path):
+    config = tmp_path / "conf.txt"
+    config.write_text("a:1\nproc:(a:1):(b:1):1\n")
+    trace_path = tmp_path / "trace.txt"
+    log_path = tmp_path / "app.log"
+    assert (
+        cli.main(
+            [
+                str(config),
+                "5",
+                "--trace",
+                str(trace_path),
+                "--verbose",
+                "--log",
+                str(log_path),
+            ]
+        )
+        == 0
+    )
+    assert "0:proc" in log_path.read_text()
+
+
+def test_verifier_cli_log(tmp_path):
+    cfg = tmp_path / "conf.txt"
+    cfg.write_text("a:1\nproc:(a:1):(b:1):1\n")
+    trace = tmp_path / "trace.txt"
+    trace.write_text("0:proc\n")
+    log_file = tmp_path / "verif.log"
+    assert (
+        verifier_cli.main(
+            [str(cfg), str(trace), "--verbose", "--log", str(log_file)]
+        )
+        == 0
+    )
+    assert "trace is valid" in log_file.read_text()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -125,18 +125,18 @@ def test_parse_long_line_rejected(tmp_path):
 
 
 class _FakeQty(str):
-    def isdigit(self) -> bool:  # type: ignore[override]
+    def isdigit(self) -> bool:
         return True
 
 
 class _FakeLine:
-    def split(self, sep: str, maxsplit: int = 1):  # type: ignore[override]
+    def split(self, sep: str, maxsplit: int = 1) -> list[str]:
         return ["a", _FakeQty("-1")]
 
 
 def test_parse_stock_negative() -> None:
     with pytest.raises(parser.ParseError):
-        parser._parse_stock(_FakeLine())
+        parser._parse_stock(_FakeLine())  # type: ignore[arg-type]
 
 
 def test_parse_resources_edge_cases_continued():


### PR DESCRIPTION
## Summary
- support `--verbose` and `--log` options for the simulator and verifier CLIs
- log each started process in the simulator
- log trace parsing and verification
- log when saving traces to disk
- add tests for the new CLI flags
- keep linting up to date

## Testing
- `make format`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6877bc6265548324acce91011334e25e