### PR TITLE
feat: watchdog error handling

### DIFF
--- a/src/krpsim/cli.py
+++ b/src/krpsim/cli.py
@@ -70,8 +70,13 @@ def main(argv: list[str] | None = None) -> int:
     for line in format_trace(trace):
         print(line)
 
+    exit_code = 0
     if sim.time >= args.delay:
         print(f"max time reached at time {sim.time}")
+        exit_code = 1
+    elif sim.deadlock:
+        print(f"deadlock detected at time {sim.time}")
+        exit_code = 1
     else:
         print(f"no more process doable at time {sim.time}")
     print("Stock:")
@@ -79,7 +84,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"{name} => {qty}")
 
     save_trace(trace, Path(args.trace))
-    return 0
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/src/krpsim/simulator.py
+++ b/src/krpsim/simulator.py
@@ -24,6 +24,7 @@ class Simulator:
         self.time = 0
         self._running: list[_RunningProcess] = []
         self.trace: list[tuple[int, str]] = []
+        self.deadlock = False
 
     def _complete_running(self) -> None:
         completed: list[_RunningProcess] = []
@@ -58,6 +59,9 @@ class Simulator:
         return started or bool(self._running)
 
     def run(self, max_time: int) -> list[tuple[int, str]]:
+        self.deadlock = False
         while self.time < max_time and self.step():
             pass
+        if not self.trace and self.config.processes:
+            self.deadlock = True
         return self.trace

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,9 +68,18 @@ def test_cli_max_time(tmp_path, capsys):
     config = tmp_path / "conf.txt"
     config.write_text("a:1\nproc:(a:1):(b:1):1\n")
     trace_path = tmp_path / "trace.txt"
-    assert cli.main([str(config), "1", "--trace", str(trace_path)]) == 0
+    assert cli.main([str(config), "1", "--trace", str(trace_path)]) == 1
     captured = capsys.readouterr()
     assert "max time reached" in captured.out
+
+
+def test_cli_deadlock(tmp_path, capsys):
+    config = tmp_path / "conf.txt"
+    config.write_text("a:0\nproc:(a:1):(a:1):1\n")
+    trace_path = tmp_path / "trace.txt"
+    assert cli.main([str(config), "5", "--trace", str(trace_path)]) == 1
+    captured = capsys.readouterr()
+    assert "deadlock detected" in captured.out
 
 
 def test_cli_verbose_and_log(tmp_path):

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -43,6 +43,17 @@ def test_no_process_possible():
     assert sim.stocks["a"] == 1
 
 
+def test_deadlock_flag() -> None:
+    cfg = parser.Config(
+        stocks={"a": 0},
+        processes={"p": parser.Process("p", {"a": 1}, {"a": 1}, 1)},
+    )
+    sim = Simulator(cfg)
+    trace = sim.run(5)
+    assert trace == []
+    assert sim.deadlock is True
+
+
 def test_optimize_time_priority():
     cfg = parser.Config(
         stocks={"a": 1},


### PR DESCRIPTION
## Summary
- detect deadlock situations in `Simulator.run`
- return error from CLI when max time is exceeded or a deadlock occurs
- test deadlock detection and CLI exit codes

## Testing
- `make format`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6878f16c62c88324a714e8d44eb3bbe5