### PR TITLE
feat: pluralize header/footer in display

### DIFF
--- a/src/krpsim/cli.py
+++ b/src/krpsim/cli.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 
 from . import parser as parser_mod
-from .display import format_trace, print_header, save_trace
+from .display import _pluralize, format_trace, print_header, save_trace
 from .parser import ParseError
 from .simulator import Simulator
 
@@ -101,7 +101,7 @@ def main(argv: list[str] | None = None) -> int:
         exit_code = 1
     else:
         print(f"no more process doable at time {sim.time}")
-    print("Stock:")
+    print(f"{_pluralize('stock', len(sim.stocks)).capitalize()}:")
     for name, qty in sim.stocks.items():
         print(f"{name} => {qty}")
 

--- a/src/krpsim/display.py
+++ b/src/krpsim/display.py
@@ -10,14 +10,20 @@ from typing import Iterable
 from .parser import Config
 
 
+def _pluralize(word: str, count: int) -> str:
+    """Return ``word`` in singular or plural form depending on ``count``."""
+    return word if count == 1 else word + "s"
+
+
 def print_header(config: Config) -> None:
     """Print introduction lines about the config."""
     optimize_count = len(config.optimize or [])
-    print(
-        "Nice file! "
-        f"{len(config.processes)} processes, {len(config.stocks)} stocks, "
-        f"{optimize_count} to optimize"
+    process_info = (
+        f"{len(config.processes)} {_pluralize('process', len(config.processes))}"
     )
+    stock_info = f"{len(config.stocks)} {_pluralize('stock', len(config.stocks))}"
+    objective_info = f"{optimize_count} {_pluralize('objective', optimize_count)}"
+    print("Nice file! " f"{process_info}, {stock_info}, {objective_info}")
     print("Evaluating ... done.")
     print("Main walk")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,7 +62,9 @@ def test_cli_valid(tmp_path, capsys):
     trace_path = tmp_path / "trace.txt"
     assert cli.main([str(config), "5", "--trace", str(trace_path)]) == 0
     captured = capsys.readouterr()
+    assert "Nice file! 1 process, 1 stock, 0 objectives" in captured.out
     assert "Main walk" in captured.out
+    assert "Stocks:" in captured.out
     assert "0:proc" in captured.out
     assert trace_path.read_text().splitlines() == ["0:proc"]
 


### PR DESCRIPTION
## Summary
- add `_pluralize` helper for simple pluralization
- show singular words in header when counts are 1
- display `Stocks:` footer with pluralization
- adjust CLI unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a0a63914c8324b7140d290798c4cc