### PR TITLE
docs: clarify delay upper bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ equipment => 0
 euro => 2
 ```
 
+⚠️ **Limite de délai** : le paramètre `<delai>` représente une borne supérieure
+exclusive. Les cycles s'exécutent tant que `time < delai`. Pour aller au bout
+de tous les processus, fournissez un délai strictement plus grand que la durée
+totale ou utilisez l'option `--run-all`.
+
 ---
 
 ## 🖥️ Utilisation (Simulation & Vérification)
@@ -134,7 +139,9 @@ euro => 2
   poetry run krpsim <chemin_fichier_config> <delai_max>
   ```
 
-  Si le système est auto-suffisant, il s’arrête à la fin du délai ou si plus aucun process n’est possible.
+  `<delai_max>` est une borne exclusive : la simulation s'arrête dès que
+  `time` est supérieur ou égal à cette valeur. Pour exécuter tous les
+  processus, utilisez un délai supérieur à la durée totale ou passez `--run-all`.
 * **Vérification de trace :**
 
   ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,10 @@ module                = "tests.*"
 disallow_untyped_defs = false
 disallow_untyped_decorators = false
 
+[[tool.mypy.overrides]]
+module = "hypothesis.*"
+ignore_missing_imports = true
+
 # --------------------------------------------------------------------------- #
 #  Pytest & coverage                                                           #
 # --------------------------------------------------------------------------- #

--- a/src/krpsim/cli.py
+++ b/src/krpsim/cli.py
@@ -21,7 +21,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "delay",
         type=int,
-        help="maximum delay allowed (positive integer)",
+        help=(
+            "maximum delay allowed (exclusive upper bound, cycles run while "
+            "time < delay)"
+        ),
     )
     parser.add_argument(
         "--trace",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ def test_cli_help(capsys):
     assert exc.value.code == 0
     captured = capsys.readouterr()
     assert "usage:" in captured.out.lower()
+    assert "exclusive upper bound" in captured.out
 
 
 def test_cli_invalid_path():
@@ -26,6 +27,11 @@ def test_cli_invalid_delay(tmp_path):
     with pytest.raises(SystemExit) as exc:
         cli.main([str(config), "0"])
     assert exc.value.code == 2
+
+
+def test_cli_delay_help_text() -> None:
+    parser = cli.build_parser()
+    assert "exclusive upper bound" in parser.format_help()
 
 
 def test_verifier_cli_help(capsys):


### PR DESCRIPTION
## Summary
- clarify exclusive upper bound for `<delai>` argument in CLI help
- document the limit in the README with a new paragraph and updated usage instructions
- check new help wording in CLI tests
- silence mypy missing imports for Hypothesis

## Testing
- `poetry run ruff check src tests`
- `poetry run mypy src tests`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_687a1453276483249b7875acaa5820ff