### PR TITLE
feat(cli): standardize header and messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,12 @@ optimize:(time;happy_client)
 ```
 Nice file! 3 processes, 4 stocks, 1 to optimize
 Evaluating ... done.
-Main walk
+Main walk:
+Optimization criteria: time, happy_client
 0:equipment_purchase
 10:product_creation
 40:delivery
-no more process doable at time 61
+No more process doable at time 61
 Stock:
 happy_client => 1
 product => 0

--- a/src/krpsim/cli.py
+++ b/src/krpsim/cli.py
@@ -97,13 +97,13 @@ def main(argv: list[str] | None = None) -> int:
 
     exit_code = 0
     if sim.time >= args.delay:
-        print(f"max time reached at time {sim.time}")
+        print(f"Max time reached at time {sim.time}")
         exit_code = 1
     elif sim.deadlock:
-        print(f"deadlock detected at time {sim.time}")
+        print(f"Deadlock detected at time {sim.time}")
         exit_code = 1
     else:
-        print(f"no more process doable at time {sim.time}")
+        print(f"No more process doable at time {sim.time}")
     stock_names = sorted(sim.config.all_stock_names())
     print("Stock(s):")
     for name in stock_names:

--- a/src/krpsim/display.py
+++ b/src/krpsim/display.py
@@ -29,7 +29,9 @@ def print_header(config: Config) -> None:
     objective_info = f"{optimize_count} {_pluralize('objective', optimize_count)}"
     print("Nice file! " f"{process_info}, {stock_info}, {objective_info}")
     print("Evaluating ... done.")
-    print("Main walk")
+    print("Main walk:")
+    if config.optimize:
+        print(f"Optimization criteria: {', '.join(config.optimize)}")
 
 
 def format_trace(trace: Iterable[tuple[int, str]]) -> list[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,7 +69,7 @@ def test_cli_valid(tmp_path, capsys):
     assert cli.main([str(config), "5", "--trace", str(trace_path)]) == 0
     captured = capsys.readouterr()
     assert "Nice file! 1 process, 1 stock, 0 objectives" in captured.out
-    assert "Main walk" in captured.out
+    assert "Main walk:" in captured.out
     assert "Stock(s):" in captured.out
     assert "0:proc" in captured.out
     assert trace_path.read_text().splitlines() == ["0:proc"]
@@ -93,7 +93,7 @@ def test_cli_max_time(tmp_path, capsys):
     trace_path = tmp_path / "trace.txt"
     assert cli.main([str(config), "1", "--trace", str(trace_path)]) == 1
     captured = capsys.readouterr()
-    assert "max time reached" in captured.out
+    assert "Max time reached" in captured.out
 
 
 def test_cli_deadlock(tmp_path, capsys):
@@ -102,7 +102,7 @@ def test_cli_deadlock(tmp_path, capsys):
     trace_path = tmp_path / "trace.txt"
     assert cli.main([str(config), "5", "--trace", str(trace_path)]) == 1
     captured = capsys.readouterr()
-    assert "deadlock detected" in captured.out
+    assert "Deadlock detected" in captured.out
 
 
 def test_cli_verbose_and_log(tmp_path):
@@ -201,4 +201,4 @@ def test_cli_run_resources(
     assert exit_code in (0, 1)
     if resource == "custom_infinite":
         assert exit_code == 1
-        assert "max time reached" in captured.out
+        assert "Max time reached" in captured.out


### PR DESCRIPTION
## Summary
- show `Main walk:` and optimization criteria in header
- capitalize CLI status messages
- update README example
- align CLI tests with new messages

## Testing
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_687a41c67cf48324a23f56e9fb61e6ec