### PR TITLE
feat(cli): align stock output

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,11 @@ Optimization criteria: time, happy_client
 10:product_creation
 40:delivery
 No more process doable at time 61
-Stock:
-happy_client => 1
-product => 0
-equipment => 0
-euro => 2
+Final Stocks:
+  happy_client  => 1
+  product       => 0
+  equipment     => 0
+  euro          => 2
 ```
 
 ⚠️ **Limite de délai** : le paramètre `<delai>` représente une borne supérieure

--- a/src/krpsim/cli.py
+++ b/src/krpsim/cli.py
@@ -105,9 +105,10 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print(f"No more process doable at time {sim.time}")
     stock_names = sorted(sim.config.all_stock_names())
-    print("Stock(s):")
+    max_len = max((len(name) for name in stock_names), default=0)
+    print("Final Stocks:")
     for name in stock_names:
-        print(f"{name} => {sim.stocks.get(name, 0)}")
+        print(f"  {name:<{max_len}}  => {sim.stocks.get(name, 0)}")
 
     return exit_code
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,7 +70,7 @@ def test_cli_valid(tmp_path, capsys):
     captured = capsys.readouterr()
     assert "Nice file! 1 process, 1 stock, 0 objectives" in captured.out
     assert "Main walk:" in captured.out
-    assert "Stock(s):" in captured.out
+    assert "Final Stocks:" in captured.out
     assert "0:proc" in captured.out
     assert trace_path.read_text().splitlines() == ["0:proc"]
 
@@ -80,11 +80,27 @@ def test_cli_lists_all_stocks(capsys: pytest.CaptureFixture[str]) -> None:
     captured = capsys.readouterr()
     assert exit_code == 0
     lines = captured.out.splitlines()
-    idx = lines.index("Stock(s):")
+    idx = lines.index("Final Stocks:")
     stocks = {
-        line.split(" => ")[0] for line in lines[idx + 1 : idx + 5] if " => " in line
+        line.split(" => ")[0].strip()
+        for line in lines[idx + 1 : idx + 5]
+        if " => " in line
     }
     assert stocks == {"client_content", "euro", "materiel", "produit"}
+
+
+def test_cli_stock_alignment(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = cli.main([str(Path("resources/simple")), "100"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    lines = captured.out.splitlines()
+    idx = lines.index("Final Stocks:")
+    stock_lines = [line for line in lines[idx + 1 : idx + 5] if "=>" in line]
+    assert stock_lines
+    arrow_pos = stock_lines[0].index("=>")
+    for line in stock_lines:
+        assert line.startswith("  ")
+        assert line.index("=>") == arrow_pos
 
 
 def test_cli_max_time(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- compute alignment length in cli
- align stock list output with "Final Stocks" header
- update README example
- test CLI stock output formatting

## Testing
- `make format`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687a456482388324a108952b8a9b1738