### PR TITLE
docs: clarify delay behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,16 @@ exclusive. Les cycles s'exécutent tant que `time < delai`. Pour aller au bout
 de tous les processus, fournissez un délai strictement plus grand que la durée
 totale ou utilisez l'option `--run-all`.
 
+Par exemple :
+
+```bash
+$ poetry run krpsim resources/simple 10
+0:achat_materiel
+Max time reached at time 10
+```
+
+Le premier processus dure exactement dix cycles ; avec un délai égal à `10`, la simulation s'arrête juste après son démarrage et aucun autre processus n'apparaît dans la trace.
+
 ---
 
 ## 🖥️ Utilisation (Simulation & Vérification)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -218,3 +218,12 @@ def test_cli_run_resources(
     if resource == "custom_infinite":
         assert exit_code == 1
         assert "Max time reached" in captured.out
+
+
+def test_cli_partial_execution_small_delay(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = cli.main([str(Path("resources/simple")), "10"])
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Max time reached" in captured.out
+    assert "0:achat_materiel" in captured.out
+    assert "realisation_produit" not in captured.out


### PR DESCRIPTION
## Summary
- expand README section explaining time limit
- provide example of partial simulation
- assert CLI stops processes when delay is too small

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687a4b844a5083249a5031a0411cf516