### PR TITLE
feat: include delay boundary in simulation

### DIFF
--- a/src/krpsim/cli.py
+++ b/src/krpsim/cli.py
@@ -97,7 +97,8 @@ def main(argv: list[str] | None = None) -> int:
 
     exit_code = 0
     if sim.time >= args.delay:
-        print(f"Max time reached at time {sim.time}")
+        limit = args.delay if sim.time > args.delay else sim.time
+        print(f"Max time reached at time {limit}")
         exit_code = 1
     elif sim.deadlock:
         print(f"Deadlock detected at time {sim.time}")

--- a/src/krpsim/simulator.py
+++ b/src/krpsim/simulator.py
@@ -60,7 +60,7 @@ class Simulator:
 
     def run(self, max_time: int) -> list[tuple[int, str]]:
         self.deadlock = False
-        while self.time < max_time and self.step():
+        while self.time <= max_time and self.step():
             pass
         if not self.trace and self.config.processes:
             self.deadlock = True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,6 +110,7 @@ def test_cli_max_time(tmp_path, capsys):
     assert cli.main([str(config), "1", "--trace", str(trace_path)]) == 1
     captured = capsys.readouterr()
     assert "Max time reached" in captured.out
+    assert "b  => 1" in captured.out
 
 
 def test_cli_deadlock(tmp_path, capsys):
@@ -226,4 +227,4 @@ def test_cli_partial_execution_small_delay(capsys: pytest.CaptureFixture[str]) -
     assert exit_code == 1
     assert "Max time reached" in captured.out
     assert "0:achat_materiel" in captured.out
-    assert "realisation_produit" not in captured.out
+    assert "10:realisation_produit" in captured.out

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -105,7 +105,7 @@ def test_run_resources(resource: str) -> None:
     sim = Simulator(cfg)
     trace = sim.run(50)
     assert trace  # at least one process started
-    assert sim.time <= 50
+    assert sim.time <= 51
 
 
 def test_custom_finite() -> None:
@@ -122,5 +122,5 @@ def test_custom_infinite() -> None:
     sim = Simulator(cfg)
     trace = sim.run(5)
     # the loop process runs every cycle until max time
-    assert trace == [(i, "loop") for i in range(5)]
-    assert sim.time == 5
+    assert trace == [(i, "loop") for i in range(6)]
+    assert sim.time == 6


### PR DESCRIPTION
## Summary
- allow the simulator to run the last cycle when time equals the delay
- show the configured delay if time surpasses the limit
- update CLI tests for new delay behaviour
- adjust simulator tests to match inclusive limit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a6559f820832495c7cf963f65de82