### PR TITLE
feat: update delay semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,20 +125,20 @@ Final Stocks:
   euro          => 2
 ```
 
-⚠️ **Limite de délai** : le paramètre `<delai>` représente une borne supérieure
-exclusive. Les cycles s'exécutent tant que `time < delai`. Pour aller au bout
-de tous les processus, fournissez un délai strictement plus grand que la durée
-totale ou utilisez l'option `--run-all`.
+⚠️ **Limite de délai** : le paramètre `<delai>` est une borne supérieure
+inclusive. La simulation se poursuit tant que `time ≤ delai`. Pour exécuter
+tous les processus sans limite, passez `--run-all`.
 
 Par exemple :
 
 ```bash
 $ poetry run krpsim resources/simple 10
 0:achat_materiel
+10:realisation_produit
 Max time reached at time 10
 ```
 
-Le premier processus dure exactement dix cycles ; avec un délai égal à `10`, la simulation s'arrête juste après son démarrage et aucun autre processus n'apparaît dans la trace.
+Le second processus démarre au cycle `10` car cette valeur est incluse dans la période d'exécution.
 
 ---
 
@@ -150,9 +150,9 @@ Le premier processus dure exactement dix cycles ; avec un délai égal à `10`
   poetry run krpsim <chemin_fichier_config> <delai_max>
   ```
 
-  `<delai_max>` est une borne exclusive : la simulation s'arrête dès que
-  `time` est supérieur ou égal à cette valeur. Pour exécuter tous les
-  processus, utilisez un délai supérieur à la durée totale ou passez `--run-all`.
+  `<delai_max>` est une borne inclusive : la simulation continue tant que
+  `time` est inférieur ou égal à cette valeur. Pour ignorer toute limite,
+  passez `--run-all`.
 * **Vérification de trace :**
 
   ```bash

--- a/src/krpsim/cli.py
+++ b/src/krpsim/cli.py
@@ -22,8 +22,8 @@ def build_parser() -> argparse.ArgumentParser:
         "delay",
         type=int,
         help=(
-            "maximum delay allowed (exclusive upper bound, cycles run while "
-            "time < delay)"
+            "maximum delay allowed (inclusive upper bound, cycles run while "
+            "time \u2264 delay)"
         ),
     )
     parser.add_argument(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ def test_cli_help(capsys):
     assert exc.value.code == 0
     captured = capsys.readouterr()
     assert "usage:" in captured.out.lower()
-    assert "exclusive upper bound" in captured.out
+    assert "inclusive upper bound" in captured.out
 
 
 def test_cli_invalid_path():
@@ -31,7 +31,7 @@ def test_cli_invalid_delay(tmp_path):
 
 def test_cli_delay_help_text() -> None:
     parser = cli.build_parser()
-    assert "exclusive upper bound" in parser.format_help()
+    assert "inclusive upper bound" in parser.format_help()
 
 
 def test_verifier_cli_help(capsys):


### PR DESCRIPTION
## Summary
- clarify that delay is an inclusive upper bound
- update README examples and usage
- adjust CLI help and related tests

## Testing
- `poetry run ruff src/krpsim tests`
- `poetry run black src/krpsim tests -q --check`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a67ccedc88324bdca452ab5b8705f