### PR TITLE
fix: correct CI and coverage badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # krpsim
 
 ![License](https://img.shields.io/github/license/raveriss/krpsim)
-![CI](https://github.com/raveriss/krpsim/actions/workflows/ci.yml/badge.svg)
-![Coverage](https://codecov.io/gh/raveriss/krpsim/branch/main/graph/badge.svg)
+![CI](https://img.shields.io/github/actions/workflow/status/raveriss/krpsim/ci.yml?branch=main&label=CI)
+![Coverage](https://img.shields.io/codecov/c/github/raveriss/krpsim?branch=main&label=coverage)
 ![Pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen)
 ![Version](https://img.shields.io/badge/version-0.1.0-blue)
 


### PR DESCRIPTION
## Summary
- fix CI badge to use shields.io status endpoint for main branch
- fix coverage badge to display Codecov metrics consistently

## Testing
- `SKIP=xenon pre-commit run --files README.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c720aff608324969dfb6887e112c4