### PR TITLE
fix: correct Codecov badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![License](https://img.shields.io/github/license/raveriss/krpsim)
 ![CI](https://img.shields.io/github/actions/workflow/status/raveriss/krpsim/ci.yml?branch=main&label=CI)
-[![codecov](https://codecov.io/gh/raveriss/krpsim/graph/badge.svg?token=KWEMWRLVDA)](https://codecov.io/gh/raveriss/krpsim)
+[![codecov](https://codecov.io/gh/raveriss/krpsim/branch/main/graph/badge.svg)](https://codecov.io/gh/raveriss/krpsim)
 ![Pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen)
 ![Version](https://img.shields.io/badge/version-0.1.0-blue)
 


### PR DESCRIPTION
## Summary
- fix Codecov badge URL to use public branch coverage and remove token

## Testing
- `python -m pre_commit run --files README.md`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689db57317488324870d5b0f6be246ca