### PR TITLE
ci: simplify Codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,43 +115,16 @@ jobs:
           head -n 20 coverage.xml || true
           test -f coverage.xml || (echo "coverage.xml missing" && exit 1)
 
-      - name: Upload coverage to Codecov (action v5, strict, slug)
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
           disable_search: true
           flags: unittests
-          verbose: true
-          fail_ci_if_error: true
-          slug: raveriss/krpsim
-          commit_sha: ${{ github.sha }}
-          branch: ${{ github.ref_name }}
           name: ci-ubuntu-py310
-
-      - name: Also upload coverage as artifact (debug)
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage.xml
-          path: coverage.xml
-          if-no-files-found: error
-
-      # Fallback ultra-verbeux (si jamais l'action ne poste pas de rapport)
-      - name: Download Codecov uploader
-        run: |
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-          ./codecov --version
-
-      - name: Upload via Codecov CLI (strict, same context)
-        run: |
-          ./codecov \
-            -f coverage.xml \
-            -Z \
-            -n ci-ubuntu-py310 \
-            -r raveriss/krpsim \
-            -B "${GITHUB_REF_NAME}" \
-            -C "${GITHUB_SHA}" \
-            -v
+          slug: raveriss/krpsim
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
   build:
     name: Build Package

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
## Summary
- use a single Codecov action with repository token and allow non-blocking failures
- remove fallback CLI upload and add Codecov config for informational checks

## Testing
- `poetry run pre-commit run --files .github/workflows/ci.yml codecov.yml`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689de9a5251c8324a1573465a17fad1a