### PR TITLE
fix: upload coverage to codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,13 +143,13 @@ jobs:
         run: poetry install --no-interaction
 
       - name: Run tests
-        run: poetry run pytest --cov=src/krpsim--cov-report=xml --cov-report=term-missing
+        run: poetry run pytest
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         uses: codecov/codecov-action@v4
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- run full test suite during CI and upload coverage report to Codecov

## Testing
- `poetry run pre-commit run --files .github/workflows/ci.yml`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a18e3e144483249f41478ed85f30e5